### PR TITLE
Fix MoonBit nightly CI warnings

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,8 +14,8 @@ jobs:
 
       - name: Setup Moonbit
         uses: hustcer/setup-moonbit@v1
-        # with:
-        #   version: "nightly"
+        with:
+          version: "nightly"
 
       - uses: actions/setup-node@v4
         with:
@@ -49,6 +49,7 @@ jobs:
       #     git diff
 
       - name: Deploy to server
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: deploy
         uses: Pendect/action-rsyncer@v2.0.0
         env:
@@ -61,4 +62,5 @@ jobs:
           dest: "rsync-user@tiye.me:/web-assets/repo/${{ github.repository }}"
 
       - name: Display status from deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: echo "${{ steps.deploy.outputs.status }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 target/
 .mooncakes/
+dist/
 
 node_modules
+
+_build

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <!-- <script src="./main.mjs" type="module"></script> -->
     <div class="app"></div>
     <script
-      src="./target/js/debug/build/app.js"
+      src="./_build/js/debug/build/app.js"
       type="module"
       defer
     ></script>

--- a/src/main.mbt
+++ b/src/main.mbt
@@ -29,14 +29,14 @@ fn main {
   if window.document().query_selector(".app") is Some(mount_target) {
     let mount_target = mount_target.reinterpret_as_node()
     let app : @respo.RespoApp[Store] = {
-      store: Ref::new(@respo.try_load_storage(app_store_key)),
+      store: Ref(@respo.try_load_storage(app_store_key)),
       mount_target,
       storage_key: app_store_key,
     }
     app.backup_model_beforeunload()
     // @dom_ffi.log("store: " + app.store.val.to_json().stringify(indent=2))
-    app.render_loop(fn() { view(app.store.val) }, fn(op) {
-      if not(op is StatesChange(_)) {
+    app.render_loop(() => view(app.store.val), (op) => {
+      if !(op is StatesChange(_)) {
         @dom_ffi.log("Action: \{op}")
       }
       app.store.val = app.store.val.update(op)

--- a/src/moon.pkg.json
+++ b/src/moon.pkg.json
@@ -2,6 +2,14 @@
   "is-main": true,
   "import": [
     {
+      "path": "moonbitlang/core/json",
+      "alias": "json"
+    },
+    {
+      "path": "moonbitlang/core/debug",
+      "alias": "debug"
+    },
+    {
       "path": "tiye/respo",
       "alias": "respo"
     },

--- a/src/store.mbt
+++ b/src/store.mbt
@@ -33,8 +33,11 @@ impl @respo_node.RespoAction for ActionOp with build_states_action(cursor, a, j)
 ///|
 impl Show for ActionOp with output(self, logger) -> Unit {
   let s = match self {
-    StatesChange(state) =>
-      "StatesChange(\{state.cursor} \{state.backup.to_json()})"
+    StatesChange(state) => {
+      let cursor = @debug.to_string(state.cursor)
+      let backup = state.backup.to_json().stringify()
+      "StatesChange(\{cursor} \{backup})"
+    }
     // Intent(_intent) => "Intent(...)"
     Increment => "Increment"
     Decrement => "Decrement"


### PR DESCRIPTION
## Summary
- keep GitHub Actions on MoonBit nightly explicitly
- avoid running deploy steps on pull requests
- fix current MoonBit nightly deprecation warnings in the app sources

## Validation
- moon check --target js
- moon update && moon check --target js && moon build --target js --debug && yarn vite build --base=./